### PR TITLE
Add option to diagnose only for selected users after their authentication and more

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,11 @@
+filter:
+    excluded_paths:
+        - 'l10n/*'
+
+imports:
+    - javascript
+    - php
+
+tools:
+    external_code_coverage:
+        timeout: 1200 # Timeout in seconds. 20 minutes

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -26,6 +26,16 @@ $application->registerRoutes(
 	[
 		'routes' => [
 			[
+				'name' => 'Admin#setDiagnosticForUsers',
+				'url' => '/setdiagnosticforusers',
+				'verb' => 'POST'
+			],
+			[
+				'name' => 'Admin#getDiagnosedUsers',
+				'url' => '/getdiagnosedusers',
+				'verb' => 'GET'
+			],
+			[
 				'name' => 'Admin#setDebug',
 				'url' => '/setdebug',
 				'verb' => 'POST'

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -50,6 +50,20 @@ class AdminController extends Controller {
 	}
 
 	/**
+	 * @param string $uids - e.g. "["admin","user1000"]" in JSON format
+	 */
+	public function setDiagnosticForUsers($uids) {
+		$this->diagnostics->setDiagnosticForUsers($uids);
+	}
+
+	/**
+	 * @return string[] $uid
+	 */
+	public function getDiagnosedUsers() {
+		return $this->diagnostics->getDiagnosedUsers();
+	}
+	
+	/**
 	 * @return bool
 	 */
 	public function isDebugEnabled() {

--- a/lib/Panels/Admin.php
+++ b/lib/Panels/Admin.php
@@ -25,17 +25,22 @@ use OCP\Settings\ISettings;
 use OCP\Template;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use OCP\IURLGenerator;
+use OCP\IUserSession;
 
 class Admin implements ISettings {
 
 	/** @var IConfig */
 	protected $config;
+	/** @var IUserSession */
+	protected $session;
 	/** @var IURLGenerator  */
 	protected $urlGenerator;
 
 	public function __construct(IConfig $config,
+								IUserSession $session,
 								IURLGenerator $urlGenerator) {
 		$this->config = $config;
+		$this->session = $session;
 		$this->urlGenerator = $urlGenerator;
 	}
 
@@ -50,13 +55,15 @@ class Admin implements ISettings {
 	public function getPanel() {
 		$template = new Template('diagnostics', 'settings-admin');
 		$diagnostics = new \OCA\Diagnostics\Diagnostics(
-			$this->config
+			$this->config,
+			$this->session
 		);
 
 		$template->assign('enableDiagnostics', $diagnostics->isDebugEnabled());
 		$template->assign('diagnosticLogLevel', $diagnostics->getDiagnosticLogLevel());
 		$template->assign('urlGenerator', $this->urlGenerator);
 		$template->assign('logFileSize', $diagnostics->getLogFileSize());
+		$template->assign('diagnoseUsers', implode('|', $diagnostics->getDiagnosedUsers()));
 		return $template;
 	}
 

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -17,40 +17,35 @@ style('diagnostics', 'settings-admin');
 ?>
 <div id="ocDiagnosticsSettings" class="section">
 	<h2 class="app-name"><?php p($l->t('Diagnostics')); ?></h2>
-	<em><?php
+	<em>
+		<?php
 		p($l->t('Enabling this ownCloud diagnostic module will result in collecting data '.
-			'about all queries and events in the system per request.' )
-		);
-		?></em>
+			'about all queries and events in the system per request.' ));
+		?>
+	</em>
 
+	<br/>
+	<br/>
+	<div id="diagnosticLog" <?php if ($_['enableDiagnostics']) print_unescaped('class="hidden"'); ?>>
+		<?php p($l->t('Collect data only after authentication of users:')); ?>
+		<br/>
+		<input name="diagnosticUserList" id="diagnosticUserList" value="<?php p($_['diagnoseUsers']) ?>" style="width: 400px">
+		<br/>
+		<em>
+			<?php p($l->t('Please specify full user name for best search performance')); ?>
+		</em>
+	</div>
 	<p>
 		<input type="checkbox" class="checkbox" name="enableDiagnostics" id="enableDiagnostics"
 			   value="1" <?php if ($_['enableDiagnostics']) print_unescaped('checked="checked"'); ?> />
-		<label for="enableDiagnostics"><?php p($l->t('Enable diagnostic data collection'));?></label>
+		<label for="enableDiagnostics"><?php p($l->t('Allow collecting all data (including unauthenticated requests, debug mode)'));?></label>
 	</p></br>
-	<span class="msg"></span>
 
-	<?php if ($_['logFileSize'] > 0): ?>
-		<a href="<?php print_unescaped($_['urlGenerator']->linkToRoute('diagnostics.Admin.downloadLog')); ?>" class="button">
-			<?php p($l->t('Download logfile (%s)', [\OCP\Util::humanFileSize($_['logFileSize'])]));?>
-		</a>
-		<a class="button" id='cleanDiagnosticLog'>
-			<?php p($l->t('Clean logfile'));?>
-		</a>
-	<?php endif; ?>
-	<?php if ($_['logFileSize'] > (100 * 1024 * 1024)): ?>
-		<br>
-		<em>
-			<?php p($l->t('The logfile is bigger than 100 MB. Downloading it may take some time!')); ?>
-		</em>
-	<?php endif; ?>
 
-	<br/>
-	<br/>
-	<div id="diagnosticLog" <?php if (!$_['enableDiagnostics']) print_unescaped('class="hidden"'); ?>>
 	<h2 id='diagnosticLogLevelText'>
 		<?php p($l->t('What to log'));?>
 	</h2>
+
 	<select name='diagnosticLogLevel' id='diagnosticLogLevel'>
 		<?php for ($i = 0; $i < 5; $i++):
 			$selected = '';
@@ -61,6 +56,39 @@ style('diagnostics', 'settings-admin');
 		<?php endfor;?>
 
 	</select>
-	</div>
+	<br/>
+	<em>
+		<?php p($l->t('Decide what details should be included in the log file')); ?>
+	</em>
+
+	<br/>
+	<br/>
+	<h2 id='diagnosticLogText'>
+		<?php p($l->t('Diagnostic Log'));?>
+	</h2>
+	<?php if ($_['logFileSize'] > 0): ?>
+		<a href="<?php print_unescaped($_['urlGenerator']->linkToRoute('diagnostics.Admin.downloadLog')); ?>" class="button">
+			<?php p($l->t('Download logfile (%s)', [\OCP\Util::humanFileSize($_['logFileSize'])]));?>
+		</a>
+		<a class="button" id='cleanDiagnosticLog'>
+			<?php p($l->t('Clean logfile'));?>
+		</a>
+		<br/>
+		<br/>
+		<em>
+			<?php p($l->t('Log file is located by default in ./data/diagnostic.log')); ?>
+		</em>
+	<?php endif; ?>
+	<?php if ($_['logFileSize'] === 0): ?>
+		<em>
+			<?php p($l->t('The logfile is empty!')); ?>
+		</em>
+	<?php endif; ?>
+	<?php if ($_['logFileSize'] > (100 * 1024 * 1024)): ?>
+		<br>
+		<em>
+			<?php p($l->t('The logfile is bigger than 100 MB. Downloading it may take some time!')); ?>
+		</em>
+	<?php endif; ?>
 </div>
 

--- a/tests/Controller/AdminControllerTest.php
+++ b/tests/Controller/AdminControllerTest.php
@@ -24,8 +24,11 @@ namespace OCA\Diagnostics\Tests\Controller;
 use OCA\Diagnostics\Controller\AdminController;
 use OCA\Diagnostics\DataSource;
 use OCA\Diagnostics\Diagnostics;
+use OCP\IRequest;
+use OCP\IL10N;
 use OCP\AppFramework\Http;
 use Test\TestCase;
+use OCP\AppFramework\Http\StreamResponse;
 
 class AdminControllerTest extends TestCase {
 
@@ -48,9 +51,9 @@ class AdminControllerTest extends TestCase {
 
 		parent::setUp();
 
-		$this->requestMock = $this->createMock('OCP\IRequest');
+		$this->requestMock = $this->createMock(IRequest::class);
 
-		$this->l10nMock = $this->getMockBuilder('OCP\IL10N')
+		$this->l10nMock = $this->getMockBuilder(IL10N::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->l10nMock->expects($this->any())
@@ -59,7 +62,7 @@ class AdminControllerTest extends TestCase {
 				return $message;
 			}));
 
-		$this->diagnostics = $this->getMockBuilder('OCA\Diagnostics\Diagnostics')
+		$this->diagnostics = $this->getMockBuilder(Diagnostics::class)
 			->disableOriginalConstructor()
 			->setMethods([
 				'isDebugEnabled',
@@ -68,9 +71,11 @@ class AdminControllerTest extends TestCase {
 				'setDiagnosticLogLevel',
 				'downloadLog',
 				'cleanLog',
+				'getDiagnosedUsers',
+				'setDiagnosticForUsers',
 			])->getMock();
 
-		$this->datasource = $this->getMockBuilder('OCA\Diagnostics\DataSource')
+		$this->datasource = $this->getMockBuilder(DataSource::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->controller = new AdminController(
@@ -96,6 +101,20 @@ class AdminControllerTest extends TestCase {
 		$this->assertSame('1', $response);
 	}
 
+	public function testGetDiagnosedUsers() {
+		$this->diagnostics->expects($this->once())
+			->method('getDiagnosedUsers')
+			->willReturn(["admin", "user100"]);
+		$response = $this->controller->getDiagnosedUsers();
+		$this->assertSame(["admin", "user100"], $response);
+	}
+
+	public function testSetDiagnosticForUsers() {
+		$this->diagnostics->expects($this->once())
+			->method('setDiagnosticForUsers');
+		$this->controller->setDiagnosticForUsers("[\"admin\", \"user100\"]");
+	}
+
 	public function testSetDebug() {
 		$this->diagnostics->expects($this->once())
 			->method('setDebug');
@@ -117,13 +136,13 @@ class AdminControllerTest extends TestCase {
 	}
 
 	public function testDownloadLog() {
-		$streamResponse = $this->getMockBuilder('OCP\AppFramework\Http\StreamResponse')
+		$streamResponse = $this->getMockBuilder(StreamResponse::class)
 			->disableOriginalConstructor()->getMock();
 		$this->diagnostics->expects($this->once())
 			->method('downloadLog')
 			->willReturn($streamResponse);
 
 		$response = $this->controller->downloadLog();
-		$this->assertInstanceOf('\OCP\AppFramework\Http\StreamResponse', $response);
+		$this->assertInstanceOf(StreamResponse::class, $response);
 	}
 }

--- a/tests/Panels/AdminTest.php
+++ b/tests/Panels/AdminTest.php
@@ -24,6 +24,7 @@ namespace OCA\Diagnostics\Tests\Panels;
 use OCA\Diagnostics\Panels\Admin;
 use OCP\IConfig;
 use OCP\IURLGenerator;
+use OCP\IUserSession;
 
 /**
  * @package OCA\Diagnostics\Tests\Panels
@@ -32,16 +33,29 @@ class AdminTest extends \Test\TestCase {
 
 	/** @var IConfig */
 	private $config;
+	/** @var IUserSession */
+	private $session;
 	/** @var IURLGenerator */
 	private $logger;
+	/** @var Admin */
+	private $panel;
 
 	public function setUp() {
 		parent::setUp();
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->urlgen = $this->getMockBuilder(IURLGenerator::class)->getMock();
+
+		$this->config = $this->getMockBuilder(IConfig::class)
+			->disableOriginalConstructor()->getMock();
+		$this->config
+			->method('getAppValue')
+			->willReturn("[]");
+
+		$this->logger = $this->getMockBuilder(IURLGenerator::class)->getMock();
+		$this->session = $this->getMockBuilder(IUserSession::class)->getMock();
+
 		$this->panel = new Admin(
 			$this->config,
-			$this->urlgen);
+			$this->session,
+			$this->logger);
 	}
 
 	public function testGetSection() {


### PR DESCRIPTION
- [x] Requires this to be merged: https://github.com/owncloud/core/pull/27643 otherwise UNIT TESTs will fail. 

This also means that this app would need separate branches for earlier versions - @DeepDiver1975 @PVince81 

- Add option to diagnose only for selected users after their authentication. This basicaly means that you can collect data from some users not affecting performance of production system of other users, because for them data wont be collected and logged. @DeepDiver1975 @felixboehm 
- Allow debug mode - collecing for unauthenticated users
- Add scrutizer,
- improve code quality
- log section
- better log file logging
- Unit tests

![selection_182](https://cloud.githubusercontent.com/assets/13368647/25029041/d1aa6b0a-20b9-11e7-8114-c1cf0ab4201a.jpg)
