### PR TITLE
Sort entries by timestamp to build a logical timeline

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -26,9 +26,9 @@ register_shutdown_function(function () use ($application) {
 	$application->finalizeRequest();
 });
 
-if (!(defined('PHPUNIT_RUN'))) {
+if (!defined('PHPUNIT') && !\OC::$CLI) {
 	$pathInfo = \OC::$server->getRequest()->getPathInfo();
-	if (strstr($pathInfo, 'settings/') != false) {
+	if (strstr($pathInfo, 'settings/') !== false) {
 		// Temporarily fix icon until custom icons are supported
 		\OCP\Util::addStyle('diagnostics', 'icon');
 	}

--- a/lib/DataSource.php
+++ b/lib/DataSource.php
@@ -134,5 +134,6 @@ class DataSource {
 		if ($totalDBQueries>0 && $totalEvents>0){
 			$this->diagnostics->recordSummary($totalDBQueries, $totalDBDuration, $totalDBParams, $totalEvents, $totalEventsDuration);
 		}
+		$this->diagnostics->commit();
 	}
 }

--- a/lib/Diagnostics.php
+++ b/lib/Diagnostics.php
@@ -183,7 +183,7 @@ class Diagnostics {
 				'sqlQueryDurationmsec',
 				'sqlTimestamp'
 			);
-			$this->diagnosticLogger->write(OwnCloudLog::QUERY_TYPE, $entry);
+			$this->diagnosticLogger->write(OwnCloudLog::QUERY_TYPE, $entry, $sqlTimestamp);
 			return true;
 		}
 		return false;
@@ -204,7 +204,7 @@ class Diagnostics {
 				'eventTimestamp'
 			);
 
-			$this->diagnosticLogger->write(OwnCloudLog::EVENT_TYPE, $entry);
+			$this->diagnosticLogger->write(OwnCloudLog::EVENT_TYPE, $entry, $eventTimestamp);
 			return true;
 		}
 		return false;
@@ -234,7 +234,16 @@ class Diagnostics {
 		}
 		return false;
 	}
-	
+
+	/*
+	 * Signals that recording diagnostic entries is finished
+	 */
+	public function commit() {
+		if ($this->getDiagnosticLogLevel() !== Diagnostics::LOG_NOTHING) {
+			$this->diagnosticLogger->commit();
+		}
+	}
+
 	/**
 	 * get logfile filesize
 	 *

--- a/tests/DataSourceTest.php
+++ b/tests/DataSourceTest.php
@@ -56,6 +56,7 @@ class DataSourceTest extends \Test\TestCase {
 				'recordEvent',
 				'recordQuery',
 				'recordSummary',
+				'commit',
 				'isDiagnosticActivatedForSession'
 			])->getMock();
 
@@ -130,6 +131,9 @@ class DataSourceTest extends \Test\TestCase {
 				$this->anything()
 			);
 
+		$this->diagnostics->expects($this->once())
+			->method('commit');
+
 		$this->datasource->diagnoseRequest();
 	}
 
@@ -153,6 +157,9 @@ class DataSourceTest extends \Test\TestCase {
 
 		$this->diagnostics->expects($this->never())
 			->method('recordSummary');
+
+		$this->diagnostics->expects($this->once())
+			->method('commit');
 
 		$this->datasource->diagnoseRequest();
 	}

--- a/tests/DiagnosticsTest.php
+++ b/tests/DiagnosticsTest.php
@@ -190,6 +190,7 @@ class DiagnosticsTest extends \Test\TestCase {
 		$this->diagnostics->recordEvent("APPLoad", 0.1, 1492118966.234);
 		$this->diagnostics->recordEvent("mountFS", 10.1, 1492118966.854);
 		$this->diagnostics->recordSummary(2, 300.999, 2, 2, 10.2);
+		$this->diagnostics->commit();
 	}
 
 	public function testLogging() {


### PR DESCRIPTION
1. Now all entries (events, queries, summary) are sorted in order as they were recorded
2. Now records need to be commited to be written to disk (no need to open and close the file all the time)