### PR TITLE
Adjust phpstan and AdminController issues

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -63,9 +63,7 @@ class Application extends \OCP\AppFramework\App {
 			return new AdminController(
 				$c->getAppName(),
 				$server->getRequest(),
-				$server->getL10N($c->getAppName()),
-				$c->query('Diagnostics'),
-				$c->query('DataSource')
+				$c->query('Diagnostics')
 			);
 		});
 	}

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -22,9 +22,7 @@
 namespace OCA\Diagnostics\Controller;
 
 use OCA\Diagnostics\Diagnostics;
-use OCA\Diagnostics\DataSource;
 use OCP\AppFramework\Controller;
-use OCP\IL10N;
 use OCP\IRequest;
 use OCP\AppFramework\Http\StreamResponse;
 
@@ -36,14 +34,11 @@ class AdminController extends Controller {
 	/**
 	 * @param string $AppName
 	 * @param IRequest $request
-	 * @param IL10N $l10n
 	 * @param Diagnostics $diagnostics
 	 */
 	public function __construct($AppName,
 								IRequest $request,
-								IL10N $l10n,
-								Diagnostics $diagnostics,
-								DataSource $dataSource
+								Diagnostics $diagnostics
 	) {
 		parent::__construct($AppName, $request);
 		$this->diagnostics = $diagnostics;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,8 @@
 parameters:
   inferPrivatePropertyTypeFromConstructor: true
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   excludes_analyse:
     - %currentWorkingDirectory%/appinfo/routes.php
     - %currentWorkingDirectory%/appinfo/app.php
   ignoreErrors:
-    -
-       message: '#Constructor of class OCA\\Diagnostics\\Controller\\AdminController has an unused parameter [a-zA-Z0-9\.\$]+#'
-       path: %currentWorkingDirectory%/lib/Controller/AdminController.php

--- a/tests/unit/Controller/AdminControllerTest.php
+++ b/tests/unit/Controller/AdminControllerTest.php
@@ -38,28 +38,13 @@ class AdminControllerTest extends TestCase {
 	/** @var Diagnostics */
 	private $diagnostics;
 
-	/** @var DataSource */
-	private $datasource;
-
 	/** @var \OCP\IRequest|\PHPUnit_Framework_MockObject_MockObject */
 	private $requestMock;
-
-	/** @var \OCP\IL10N|\PHPUnit_Framework_MockObject_MockObject */
-	private $l10nMock;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->requestMock = $this->createMock(IRequest::class);
-
-		$this->l10nMock = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
-
-		$this->l10nMock->expects($this->any())
-			->method('t')
-			->will($this->returnCallback(function ($message) {
-				return $message;
-			}));
 
 		$this->diagnostics = $this->getMockBuilder(Diagnostics::class)
 			->disableOriginalConstructor()
@@ -74,15 +59,10 @@ class AdminControllerTest extends TestCase {
 				'setDiagnosticForUsers',
 			])->getMock();
 
-		$this->datasource = $this->getMockBuilder(DataSource::class)
-			->disableOriginalConstructor()->getMock();
-
 		$this->controller = new AdminController(
 			'diagnostics',
 			$this->requestMock,
-			$this->l10nMock,
-			$this->diagnostics,
-			$this->datasource
+			$this->diagnostics
 		);
 	}
 


### PR DESCRIPTION
- adjust `phpstan.neon` for new `bootstrapFiles` section.
- remove unused parameters from `AdminController` constructor.
- adjust the unit tests to remove the unused parameters

Back in the original PR #1 there was `$l10n` and `$dataSource` but they were not used then, and are not used now.