### PR TITLE
[tests-only] Enable phan version 3

### DIFF
--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^2.7"
+        "phan/phan": "^3.2"
     }
 }


### PR DESCRIPTION
`phan` major version 3 was released a while ago - use .it.