### PR TITLE
Adjust PHP dependencies for composer 2.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -196,6 +196,7 @@ def phpstan():
 	default = {
 		'phpVersions': ['7.2'],
 		'logLevel': '2',
+		'extraApps': {},
 	}
 
 	if 'defaults' in config:
@@ -235,6 +236,7 @@ def phpstan():
 				'steps':
 					installCore('daily-master-qa', 'sqlite', False) +
 					installApp(phpVersion) +
+					installExtraApps(phpVersion, params['extraApps']) +
 					setupServerAndApp(phpVersion, params['logLevel']) +
 				[
 					{

--- a/.drone.star
+++ b/.drone.star
@@ -840,7 +840,7 @@ def acceptance():
 									},
 									'steps':
 										installCore(server, db, params['useBundledApp']) +
-										installTestrunner(phpVersion, params['useBundledApp']) +
+										installTestrunner('7.4', params['useBundledApp']) +
 										(installFederated(server, phpVersion, params['logLevel'], db, federationDbSuffix) + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
 										installApp(phpVersion) +
 										installExtraApps(phpVersion, params['extraApps']) +
@@ -853,7 +853,7 @@ def acceptance():
 									[
 										({
 											'name': 'acceptance-tests',
-											'image': 'owncloudci/php:%s' % phpVersion,
+											'image': 'owncloudci/php:7.4',
 											'pull': 'always',
 											'environment': environment,
 											'commands': params['extraCommandsBeforeTestRun'] + [

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "902d2d76dc194ce6a50a195e719bf484",
@@ -51,6 +51,10 @@
                 "isolation",
                 "tool"
             ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -63,5 +67,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/38067

See issue for details - `behat` acceptance tests need to use PHP  7.4 for the dependencies to sort themselves out with composer 2.0

Note: this repo does not have behat acceptance tests. This PR is just to keep `.drone.star` up-to-date etc.