### PR TITLE
Conditionally use locks for the diagnostic.log file

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -46,6 +46,11 @@ $application->registerRoutes(
 				'verb' => 'POST'
 			],
 			[
+				'name' => 'Admin#setLoggingLocks',
+				'url' => '/setlogginglocks',
+				'verb' => 'POST'
+			],
+			[
 				'name' => 'Admin#downloadLog',
 				'url' => '/log/download',
 				'verb' => 'GET'

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -107,7 +107,7 @@ OCA.DiagnosticUsers = _.extend(OC.Settings, {
 });
 
 (function( $ ) {
- 
+
     // ocDiagnosticsAddServer
     $.fn.ocDiagnosticsAddServer = function() {
 
@@ -117,11 +117,12 @@ OCA.DiagnosticUsers = _.extend(OC.Settings, {
         var $wrapper = $(this),
             $inpEnableDiagnostics = $wrapper.find("#enableDiagnostics"),
             $inpDiagnosticLogLevel = $wrapper.find("#diagnosticLogLevel"),
+            $inpUseLoggingLocks = $wrapper.find("#useLoggingLocks"),
             $cleanDiagnosticLog = $wrapper.find("#cleanDiagnosticLog"),
             $diagnosticLog = $wrapper.find("#diagnosticLog"),
             $diagnosticUserList = $wrapper.find("#diagnosticUserList");
 
-        
+
         /* Interaction
          ========================================================================== */
 
@@ -143,6 +144,16 @@ OCA.DiagnosticUsers = _.extend(OC.Settings, {
                 OC.generateUrl('/apps/diagnostics/setdiaglevel'),
                 {
                     logLevel: value
+                }
+            );
+        });
+
+        $inpUseLoggingLocks.on("change", function() {
+            var checked = $(this).is(':checked');
+            $.post(
+                OC.generateUrl('/apps/diagnostics/setlogginglocks'),
+                {
+                    enable: checked
                 }
             );
         });
@@ -180,7 +191,7 @@ OCA.DiagnosticUsers = _.extend(OC.Settings, {
 
 
 
- 
+
 })( jQuery );
 
 $(document).ready(function () {

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -57,7 +57,21 @@ class AdminController extends Controller {
 	public function getDiagnosedUsers() {
 		return $this->diagnostics->getDiagnosedUsers();
 	}
-	
+
+	/**
+	 * @param bool $enable
+	 */
+	public function setLoggingLocks($enable) {
+		$this->diagnostics->setLoggingLocks($enable);
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getLoggingLocks() {
+		return $this->diagnostics->getLoggingLocks();
+	}
+
 	/**
 	 * @return bool
 	 */

--- a/lib/Diagnostics.php
+++ b/lib/Diagnostics.php
@@ -129,6 +129,27 @@ class Diagnostics {
 	}
 
 	/**
+	 * Sets whether the logging funtionality should use locks or not
+	 * @param bool $state
+	 */
+	public function setLoggingLocks($state) {
+		$value = 'no';
+		if ($state) {
+			$value = 'yes';
+		}
+		$this->config->setAppValue('diagnostics', 'loggingLocks', $value);
+	}
+
+	/**
+	 * Gets whether the logging funtionality should use locks or not
+	 * @return bool
+	 */
+	public function getLoggingLocks() {
+		$value = $this->config->getAppValue('diagnostics', 'loggingLocks', 'no');
+		return \filter_var($value, FILTER_VALIDATE_BOOLEAN);
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function isDebugEnabled() {

--- a/lib/Panels/Admin.php
+++ b/lib/Panels/Admin.php
@@ -60,6 +60,7 @@ class Admin implements ISettings {
 
 		$template->assign('enableDiagnostics', $diagnostics->isDebugEnabled());
 		$template->assign('diagnosticLogLevel', $diagnostics->getDiagnosticLogLevel());
+		$template->assign('useLoggingLocks', $diagnostics->getLoggingLocks());
 		$template->assign('urlGenerator', $this->urlGenerator);
 		$template->assign('logFileSize', $diagnostics->getLogFileSize());
 		$template->assign('diagnosedUsers', $diagnostics->getDiagnosedUsers());

--- a/templates/settings-admin.php
+++ b/templates/settings-admin.php
@@ -54,6 +54,13 @@ style('diagnostics', 'settings-admin');
 		<label for="enableDiagnostics"><?php p($l->t('Allow collecting data for all requests in debug mode (all users, unauthenticated requests)'));?></label>
 	</p></br>
 
+	<p>
+		<input type="checkbox" class="checkbox" name="useLoggingLocks" id="useLoggingLocks"
+			value="yes" <?php if ($_['useLoggingLocks']) {
+			   	print_unescaped('checked="checked"');
+			   } ?> />
+		<label for="useLoggingLocks"><?php p($l->t('Lock the diagnostic.log file while writing. Useful for HA setups with NFS for the local storage'));?></label>
+	</p></br>
 
 	<h2 id='diagnosticLogLevelText'>
 		<?php p($l->t('What to log'));?>


### PR DESCRIPTION
Fixes https://github.com/owncloud/diagnostics/issues/71

You'll likely need multiple servers connected via NFS and a heavy load to trigger the problem. Note that the file is written at the end of the request.

Taking into account that the problem has been reproduced with a custom isolated script, and that locking the file before writing has solved the problem, this is a preemptive action. Reproducing the problem with ownCloud hasn't been possible yet outside of what has been seen in the issue.
In addition, due to the performance hit of having to lock the file (and maybe waiting for the file to be unlocked), this locking mechanism is disabled by default because it might not be needed in simple installations.

Note that the checks has been performed with NFS v4.1. This solution hasn't been tested with NFS v3, and it might not work there.

Test script, for reference below. Note that the "testfile.log" is written inside a NFS directory
```
<?php
$v = $argv[1] ?? rand();
$cc = '{"type":"QUERY","reqId":"NVDLCkoWjtVvSaa9J0Kz","diagnostics":{"sqlStatement":"SELECT `fileid`, `storage`, `path`, `parent`, `name`, `mimetype`, `mimepart`, `size`, `mtime`,    `storage_mtime`, `encrypted`, `etag`, `permissions`, `checksum` FROM `oc_filecache` WHERE `storage` = ? AND `path_hash` = ?","sqlParams":"array (   0 => 3,   1 => \"6f90b186c27cea195ea22635db5b5b35\", )","sqlQueryDurationmsec":0.9229183197021484,"sqlTimestamp":1618306963.760972}}';
$json = [];
$json['arg1'] = $v;
$json00 = json_decode($cc, true);

for ($i=0; $i<50; $i++) {
  $json['arg2'] = $i;
  $json['t0'] = $json00;
  $f = fopen('testfile.log', 'a');
  flock($f,  LOCK_EX);
  fwrite($f, json_encode($json) . "\n");
  flock($f,  LOCK_UN);
  fclose($f);
}
```