### PR TITLE
Suppress PhanDeprecatedFunction for doctrine/dbal changes

### DIFF
--- a/lib/Command/Db/Stress.php
+++ b/lib/Command/Db/Stress.php
@@ -110,6 +110,7 @@ class Stress extends Command {
 			$update->execute();
 
 			$result = $select->execute();
+			/* @phan-suppress-next-line PhanDeprecatedFunction */
 			$value = $result->fetch();
 
 			$p->advance();
@@ -171,6 +172,7 @@ class Stress extends Command {
 
 			// read current value
 			$result = $select->execute();
+			/* @phan-suppress-next-line PhanDeprecatedFunction */
 			$value = $result->fetch();
 			$i = (int)$value['configvalue'];
 
@@ -181,6 +183,7 @@ class Stress extends Command {
 
 			// read current value
 			$result = $select->execute();
+			/* @phan-suppress-next-line PhanDeprecatedFunction */
 			$value = $result->fetch();
 
 			$connection->commit();


### PR DESCRIPTION
`doctrine/dbal` was updated yesterday in core https://github.com/owncloud/core/pull/38647

Some methods have been deprecated, and `phan` reports those and fails the CI.

Suppress the deprecation warnings for now.

I raised issue #74 to actually adjust the code "some time".