### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,110 +1,140 @@
 # ownCloud Diagnostics
-:hospital:
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/diagnostics/status.svg?branch=master)](https://drone.owncloud.com/owncloud/diagnostics)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_diagnostics&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_diagnostics)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_diagnostics&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_diagnostics)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_diagnostics&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_diagnostics)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-- [x] Support for 10.0
-- [x] Support for 9.1 - [on branch stable9](https://github.com/owncloud/diagnostics/tree/stable9)
-- [x] Support for 9.0 - [on branch stable9.1](https://github.com/owncloud/diagnostics/tree/stable9.1)
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-**Versions for ownCloud 9.0 and 9.1 are limited and only work in debug mode and without user interface. For more features, please update your server version to 10.0**
+An ownCloud Classic (OC10) app that collects request data and measures server performance. When enabled, it logs query and event information per request, allowing administrators to diagnose performance issues for selected users or globally. Data is stored in `data/diagnostic.log` and can be exported for monitoring purposes.
 
-Enabling this ownCloud diagnostic module will result in collecting data about all queries and events in the system per request.
+## Getting Started
 
-It will collect information about any type of the request to the server, summarize it and store in the form of log or in any other requested form (export to monitoring).
+Install the app into your ownCloud `apps` directory:
 
-Module allows to diagnose only selected users after their authentication or enabling collecting data globally for all users with "debug mode".
-
-You can collect data from selected users not affecting performance of the system of other users (data wont be collected and logged).
-
-**By default, none of users is selected - to start logging please select user or allow collecting all data**
-
-![Demo Screen](/img/demo1.jpg?raw=true "OwnCloud Diagnostics")
-
-![Demo Screen](/img/demo2.jpg?raw=true "OwnCloud Diagnostics")
-
-# Default log location
-
-Log can be found in the folder `data/diagnostic.log`
-
-# Installation
-
-To install, go to ```/apps``` in your ownCloud installation directory and ```git clone https://github.com/owncloud/diagnostics```. In the apps admin panel enable Diagnostics app.
-
-- To enable app using command line:
-
-`sudo -u www-data php occ app:enable diagnostics`
-
-
-- To enable [log levels](/lib/Diagnostics.php), e.g. "SUMMARY":
-
-`sudo -u www-data php occ config:app:set --value 1 diagnostics diagnosticLogLevel`
-
-
-- To enable logging after authentication of specific users using command line:
-
-`sudo -u www-data php occ config:app:set --value "[\"test_shareMountInit\", \"admin\"]" diagnostics diagnosedUsers`
-
-
-- To enable debug mode globally:
-
-`sudo -u www-data php occ config:system:set --value true debug`
-
-# Usage
-
-Each SUMMARY log if referencing EVENT and QUERY logs via `reqId`.
-This allows to build full timeline of the events and corresponding queries for specific type of request e.g. "PROPFIND", only for selected users, as requests are coming.
-
-**Exemplary query log:**
-
-```
-{
-    "type":"QUERY",
-    "reqId":"JaOvGavLZar0Idhpq5AE",
-    "diagnostics":{
-        "sqlStatement":"SELECT s.*, f.`fileid`, f.`path`, st.`id` AS `storage_string_id` FROM `oc_share` s LEFT JOIN `oc_filecache` f ON s.`file_source` = f.`fileid` LEFT JOIN `oc_storages` st ON f.`storage` = st.`numeric_id` WHERE (`share_type` = :dcValue1) AND (`share_with` IN (:dcValue2)) AND ((`item_type` = :dcValue3) OR (`item_type` = :dcValue4)) ORDER BY s.`id` ASC LIMIT 18446744073709551615 OFFSET 0",
-        "sqlParams":"array (   'dcValue1' => 1,   'dcValue2' =>    array (     'admin' => 'admin',   ),   'dcValue3' => 'file',   'dcValue4' => 'folder', )",
-        "sqlQueryDurationmsec":0.22697448730469,
-        "sqlTimestamp":1492690459.1778
-    }
-}
+```bash
+cd /path/to/owncloud/apps
+git clone https://github.com/owncloud/diagnostics
+sudo -u www-data php occ app:enable diagnostics
 ```
 
-**Exemplary event log:**
-```
-{
-    "type":"EVENT",
-    "reqId":"JaOvGavLZar0Idhpq5AE",
-    "diagnostics": {
-        "eventDescription":"Setup filesystem",
-        "eventDurationmsec":5.1379203796387,
-        "eventTimestamp":1492690459.1743
-    }
-}
-```
+Once enabled, select users to diagnose from the admin panel or enable global data collection via debug mode. Logs are written to `data/diagnostic.log`.
 
-**Exemplary summary log:**
+## Documentation
 
-```
-{
-    "type":"SUMMARY",
-    "reqId":"x0GaTSDAElJ0lKtCj0Wb",
-    "time":"2017-04-20T12:14:20+00:00",
-    "remoteAddr":"127.0.0.1",
-    "user":"admin",
-    "method":"PROPFIND",
-    "url":"\/owncloudtest\/remote.php\/webdav\/",
-    "diagnostics":{
-        "totalSQLQueries":19,
-        "totalSQLDurationmsec":2.1142959594727,
-        "totalSQLParams":45,
-        "totalEvents":9,
-        "totalEventsDurationmsec":5.9356689453125
-    }
-}
+- [ownCloud Server Admin Manual](https://doc.owncloud.com/server/latest/admin_manual/)
+- [ownCloud Marketplace](https://marketplace.owncloud.com/apps/diagnostics)
+
+## Part of ownCloud Classic (OC10)
+
+This app extends [ownCloud Server](https://github.com/owncloud/core) with server-side performance diagnostics. It is shipped as part of the [ownCloud Server Docker image](https://hub.docker.com/r/owncloud/server).
+
+## Configuration
+
+Configuration options for the diagnostics app:
+
+### Log Levels
+
+Set the diagnostic log level (e.g., `SUMMARY`):
+
+```bash
+sudo -u www-data php occ config:app:set --value 1 diagnostics diagnosticLogLevel
 ```
 
+### Diagnose Specific Users
 
+Enable logging for specific users only (does not affect other users' performance):
+
+```bash
+sudo -u www-data php occ config:app:set --value '["user1", "admin"]' diagnostics diagnosedUsers
+```
+
+### Enable Debug Mode (Global)
+
+```bash
+sudo -u www-data php occ config:system:set --value true debug
+```
+
+### Log Format
+
+The diagnostic log (`data/diagnostic.log`) contains three record types linked by `reqId`:
+
+- **QUERY** -- SQL statement, parameters, duration, and timestamp
+- **EVENT** -- Event description, duration, and timestamp
+- **SUMMARY** -- Per-request totals: SQL query count, total SQL duration, event count, and total event duration, along with request method, URL, user, and remote address
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/diagnostics)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,69 @@
+# AI Agent Guidelines for ownCloud Diagnostics
+
+This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) working in this repository.
+
+## Repository Overview
+- **Product family:** Classic (OC10)
+- **Primary language(s):** JavaScript
+- **Build system:** Make + Composer
+- **Test framework:** PHPUnit
+- **CI system:** GitHub Actions
+
+## Architecture & Key Paths
+
+- `appinfo/` -- App metadata and registration
+- `lib/` -- PHP application logic
+- `js/` -- Frontend JavaScript
+- `css/` -- Stylesheets
+- `templates/` -- PHP templates
+- `tests/` -- PHPUnit tests
+- `l10n/` -- Translations
+- `Makefile` -- Build and test targets
+
+## Development Conventions
+- **Branching:** master
+- **Commit messages:** DCO sign-off required (`git commit -s`)
+- **Code style:** PHP-CS-Fixer (ownCloud codestyle via `phpcs.xml` is not present, style enforced via `vendor-bin/owncloud-codestyle`)
+- **PR process:** Open a PR against `master`. All CI checks must pass.
+
+## Build & Test Commands
+```bash
+# Build
+make dist
+
+# Test
+make test-php-unit
+
+# Lint
+make test-php-style
+```
+
+## Important Constraints
+- All code contributions must be compatible with the **AGPL-3.0** license
+- Do not introduce new **copyleft-licensed dependencies** (GPL, AGPL, LGPL, MPL) without explicit discussion in an issue first. This is especially important for repos migrating to Apache 2.0.
+- Do not introduce new dependencies without discussion in an issue first
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+- Match existing code style
+- Do not refactor unrelated code in the same PR
+- Write tests for new functionality
+- Keep PRs focused and atomic


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>