### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - XXXX
 
+
+## [0.3.1] - 2026-07-22
+
+### Changed
+- Maintenance release re-signed with the ownCloud G2 code-signing certificate for the ownCloud 11.0.0 release.
+
+## [0.3.0] - 2026-06-29
+
+### Changed
+- ownCloud 11 compatible release (oc 11.0.0-rc1).
+
 ## [0.2.1] - 2024-07-24
 
 ### Fixed
@@ -39,9 +50,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
  - Initial version
 
-[Unreleased]: https://github.com/owncloud/diagnostics/compare/v0.2.1...master
+[Unreleased]: https://github.com/owncloud/diagnostics/compare/v0.3.1..master
+[0.3.1]: https://github.com/owncloud/diagnostics/compare/v0.3.0..v0.3.1
+[0.3.0]: https://github.com/owncloud/diagnostics/compare/v0.2.1..v0.3.0
 [0.2.1]: https://github.com/owncloud/diagnostics/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/owncloud/diagnostics/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/owncloud/diagnostics/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/owncloud/diagnostics/compare/v0.1.1...v0.1.2
-

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@ The application requires some configuration before it collects data. Administrat
 The gathered data will be summarized, stored as a log file and can as well be forwarded to more sophisticated monitoring and visualization tools. Additionally administrators may choose which events the Diagnostics log should contain by using predefined loglevels.</description>
 	<licence>AGPL</licence>
 	<author>Piotr Mrowczynski</author>
-	<version>0.3.0</version>
+	<version>0.3.1</version>
     	<documentation>
     		<admin>https://github.com/owncloud/diagnostics/blob/master/README.md</admin>
     	</documentation>


### PR DESCRIPTION
Patch-level version bump (0.3.0 -> 0.3.1) for the oc11 (11.0.0) complete release. Part of the G2 code-signing re-release.